### PR TITLE
Fixes for lesson 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@
 /node_modules
 /yarn-error.log
 
+vendor/bundle
 .byebug_history
 /.idea

--- a/app/views/main/_header.html.slim
+++ b/app/views/main/_header.html.slim
@@ -1,8 +1,8 @@
 .container
   ul.nav
     li.nav-item
-      = link_to 'Главная', { controller: 'main'}, class: 'nav-link'
+      = link_to 'Главная', root_path, class: 'nav-link'
     li.nav-item
-      = link_to 'Обо мне', { controller: 'about'}, class: 'nav-link'
+      = link_to 'Обо мне', about_index_path, class: 'nav-link'
     li.nav-item
-      = link_to 'Галерея', { controller: 'gallery'}, class: 'nav-link'
+      = link_to 'Галерея', gallery_index_path, class: 'nav-link'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,10 @@ Rails.application.routes.draw do
   get 'main/index'
   get 'about/index'
 
-  resources :about
-  resources :main
-  resources :gallery
-
+  resources :about, only: :index
+  resources :main, only: :index
+  resources :gallery, only: :index
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root :to => 'main#index'
+  root to: 'main#index'
 end


### PR DESCRIPTION
Очень круто!

Все работает как требовалось! Здорово, что стал использвоать ресурсы и задействовал метод root в config/routes.rb, только лучше все-таки избавляться от символа =>, там где это можно:

```
root :to => 'main#index'
```

Это фактически

```
root { :to => 'main#index' }
```

Т.е. можем записать в короткой форме

```
root { to: 'main#index' }
```

или если опустить фигурные скобки

```
root to: 'main#index'
```

Рельсовики ожидают именно такой синтаксис (хотя в интернете и книгах будет полно примеров в старом формате с =>)

Кроме того, смотри еще как можно поступить с ресурсами:

```
  resources :about
  resources :main
  resources :gallery
```

Мы эту тему пока не затрагивали, но у роутов в ресурсе есть определенная семанитка

index - индексная, списочная страница
new - форма создания новой статьи
create - обработчик формы создания
edit - форма редатирования существующей статьи
update - обработчик формы редактирования
delete - обработчик для удаления статьи

Ты правильно задействовал index, но так как другие роуты не используются, от них можно избавиться сообщив, что мы будем использовать только index

```
resources :articles, only: :index
```

Здорово, что меню вынес в паршилы _footer.html.slim и _header.html.slim, но лучше помещать их не в main вместое с index.html.slim, а в отдельную папку например views/common или views/shared. Отлично, что воспользовался хэлпером link_to, который мы еще не рассмотрели

```
.container
  ul.nav
    li.nav-item
      = link_to 'Главная', { controller: 'main'}, class: 'nav-link'
    li.nav-item
      = link_to 'Обо мне', { controller: 'about'}, class: 'nav-link'
    li.nav-item
      = link_to 'Галерея', { controller: 'gallery'}, class: 'nav-link'
```

В качестве ссылки можно не только исползовать хэш, но и задействовать специальные хэлперы

```
.container
  ul.nav
    li.nav-item
      = link_to 'Главная', root_path, class: 'nav-link'
    li.nav-item
      = link_to 'Обо мне', about_index_path, class: 'nav-link'
    li.nav-item
      = link_to 'Галерея', gallery_index_path, class: 'nav-link'
```

Это кстати решает проблему когда ты переходишь с главной / допустим на галлерею /gallery, возвращаешься на главную и у нее URL /main/index

Очень круто и добротно!